### PR TITLE
Change dir for the appdata.xml to metainfo

### DIFF
--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -1,7 +1,7 @@
 geditcodeassistanceplugin_DATA = data/codeassistance.plugin
 geditcodeassistancedata_DATA = data/codeassistance.css
 
-metainfodir = $(datadir)/appdata
+metainfodir = $(datadir)/metainfo
 metainfo_DATA = data/gedit-code-assistance.metainfo.xml
 
 EXTRA_DIST += \


### PR DESCRIPTION
The default directory for the AppStream file changed from appdata to metainfo, as can be seen in https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#sect-Metadata-GenericComponent